### PR TITLE
feat: integrate Google Analytics tracking across components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
+import GATracker from "@/components/ga-tracker";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -22,11 +24,30 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
   return (
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
+        {/* Google Analytics (GA4) - loaded only when a Measurement ID is provided */}
+        {gaMeasurementId ? (
+  <>
+    <Script
+      src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}
+      strategy="afterInteractive"
+    />
+    <Script id="ga-init" strategy="afterInteractive">
+      {`
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${gaMeasurementId}', { page_path: window.location.pathname });
+      `}
+    </Script>
+    <GATracker />
+  </>
+) : null}
         {children}
       </body>
     </html>

--- a/src/app/space/[id]/page.tsx
+++ b/src/app/space/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation"
 import { getSpaceById } from "@/app/actions"
 import SpaceDetail from "@/components/space-detail"
+import PageTracker from "@/components/page-tracker"
 
 
 export default async function SpacePage({ params }: any) {
@@ -10,7 +11,7 @@ export default async function SpacePage({ params }: any) {
     notFound()
   }
 
-  return <SpaceDetail space={space} />
+  return <><PageTracker pageType="space" pageData={{ id: space.id.toString(), name: space.name, location: space.location, category: space.space_type, slug: space.name }} /><SpaceDetail space={space} /></>
 }
 
 export async function generateMetadata({ params }: any) {

--- a/src/components/ga-tracker.tsx
+++ b/src/components/ga-tracker.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
+
+/**
+ * Google Analytics route change tracker for Next.js App Router.
+ * Sends a GA4 config call on every pathname/searchParams change.
+ */
+export default function GATracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+    if (!gaMeasurementId) return;
+
+    const search = searchParams?.toString();
+    const pagePath = search ? `${pathname}?${search}` : pathname;
+
+    // Prefer the global gtag if available
+    const gtag = (typeof window !== 'undefined' && (window as any).gtag) || undefined;
+    if (gtag) {
+      gtag('config', gaMeasurementId, {
+        page_path: pagePath,
+        page_location: typeof window !== 'undefined' ? window.location.href : undefined,
+      });
+      return;
+    }
+
+    // Fallback to dataLayer if gtag is not yet defined
+    if (typeof window !== 'undefined' && (window as any).dataLayer) {
+      (window as any).dataLayer.push([
+        'config',
+        gaMeasurementId,
+        {
+          page_path: pagePath,
+          page_location: typeof window !== 'undefined' ? window.location.href : undefined,
+        },
+      ]);
+    }
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/src/components/landing.tsx
+++ b/src/components/landing.tsx
@@ -7,10 +7,13 @@ import Footer from "./footer"
 import FeaturedWorkspaces from "./featured-workspaces"
 import { FeedbackSection } from "./feedback-section"
 import { Suspense } from "react"
+import PageTracker from "./page-tracker"
   
   export default function NomadLifeLanding() {
+    
     return (
       <div className="min-h-screen bg-white">
+      <PageTracker pageType="homepage" />
       <Header />
       <HeroSection />
       <FeaturedWorkspaces />

--- a/src/components/page-tracker.tsx
+++ b/src/components/page-tracker.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface PageTrackerProps {
+  pageType: 'homepage' | 'workspace' | 'space' | 'event';
+  pageData?: {
+    id?: string;
+    name?: string;
+    location?: string;
+    category?: string;
+    slug?: string;
+  };
+}
+
+export default function PageTracker({ pageType, pageData }: PageTrackerProps) {
+  useEffect(() => {
+    // Send page-specific event to Google Analytics
+    if (typeof window !== 'undefined' && (window as any).gtag) {
+      const gtag = (window as any).gtag;
+      // Send a page-specific event based on the page type
+      switch (pageType) {
+        case 'homepage':
+          gtag('event', 'page_view_homepage', {
+            event_category: 'navigation',
+            event_label: 'homepage_visit',
+          });
+          break;
+
+        case 'workspace':
+          gtag('event', 'page_view_workspace', {
+            event_category: 'navigation',
+            event_label: pageData?.name || 'unknown_workspace',
+            workspace_id: pageData?.id,
+            workspace_slug: pageData?.slug,
+            workspace_location: pageData?.location,
+          });
+          break;
+
+        case 'space':
+          gtag('event', 'page_view_space', {
+            event_category: 'navigation',
+            event_label: pageData?.name || 'unknown_space',
+            space_id: pageData?.id,
+            space_category: pageData?.category,
+            space_location: pageData?.location,
+          });
+          break;
+
+        case 'event':
+          gtag('event', 'page_view_event', {
+            event_category: 'navigation',
+            event_label: pageData?.name || 'unknown_event',
+            event_id: pageData?.id,
+            event_location: pageData?.location,
+          });
+          break;
+      }
+
+      // Also send a general page engagement event
+      gtag('event', 'page_engagement', {
+        event_category: 'engagement',
+        page_type: pageType,
+        page_id: pageData?.id || 'unknown',
+      });
+    }
+  }, [pageType, pageData]);
+
+  return null;
+}

--- a/src/components/space-detail.tsx
+++ b/src/components/space-detail.tsx
@@ -72,6 +72,7 @@ export default function SpaceDetail({ space }: SpaceDetailProps) {
 
   return (
     <div className="min-h-screen bg-white">
+      
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white border-b border-gray-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/components/workspace-detail.tsx
+++ b/src/components/workspace-detail.tsx
@@ -31,6 +31,7 @@ import {
 } from "lucide-react"
 import ImageCarousel from "./image-carousel"
 import Link from "next/link"
+import PageTracker from "./page-tracker"
 
 interface Workspace {
   id: number
@@ -92,6 +93,7 @@ export default function WorkspaceDetail({ workspace }: WorkspaceDetailProps) {
 
   return (
     <div className="min-h-screen bg-white">
+      <PageTracker pageType="workspace" pageData={{ id: workspace.id.toString(), name: workspace.name, location: workspace.location, category: workspace.type, slug: workspace.slug }} />
       {/* Header */}
       <header className="sticky top-0 z-50 bg-white border-b border-gray-100">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
- Added `GATracker` component to track page views and route changes using Google Analytics.
- Implemented `PageTracker` component to send page-specific events for homepage, workspace, space, and event types.
- Updated `RootLayout` to conditionally load Google Analytics scripts based on the presence of a Measurement ID.
- Integrated `PageTracker` into `NomadLifeLanding`, `SpaceDetail`, and `WorkspaceDetail` components for enhanced tracking capabilities.